### PR TITLE
Fix bug with Open Sans font

### DIFF
--- a/styles/blocks/_typography.scss
+++ b/styles/blocks/_typography.scss
@@ -1,30 +1,34 @@
-@include lib-font-face(
-    $family-name: $font-family-name__base,
-    $font-path: '../fonts/opensans/light/opensans-300',
-    $font-weight: 300,
-    $font-style: normal
-);
+@if $font-family-name__base == 'Open Sans' {
 
-@include lib-font-face(
-    $family-name: $font-family-name__base,
-    $font-path: '../fonts/opensans/regular/opensans-400',
-    $font-weight: 400,
-    $font-style: normal
-);
+    @include lib-font-face(
+        $family-name: $font-family-name__base,
+        $font-path: '../fonts/opensans/light/opensans-300',
+        $font-weight: 300,
+        $font-style: normal
+    );
 
-@include lib-font-face(
-    $family-name: $font-family-name__base,
-    $font-path: '../fonts/opensans/semibold/opensans-600',
-    $font-weight: 600,
-    $font-style: normal
-);
+    @include lib-font-face(
+        $family-name: $font-family-name__base,
+        $font-path: '../fonts/opensans/regular/opensans-400',
+        $font-weight: 400,
+        $font-style: normal
+    );
 
-@include lib-font-face(
-    $family-name: $font-family-name__base,
-    $font-path: '../fonts/opensans/bold/opensans-700',
-    $font-weight: 700,
-    $font-style: normal
-);
+    @include lib-font-face(
+        $family-name: $font-family-name__base,
+        $font-path: '../fonts/opensans/semibold/opensans-600',
+        $font-weight: 600,
+        $font-style: normal
+    );
+
+    @include lib-font-face(
+        $family-name: $font-family-name__base,
+        $font-path: '../fonts/opensans/bold/opensans-700',
+        $font-weight: 700,
+        $font-style: normal
+    );
+
+}
 
 //
 //  Desktop


### PR DESCRIPTION
When changing the themes default font-family, prevent loading Open Sans font files using the new font family name.